### PR TITLE
Don't translate variables

### DIFF
--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -384,10 +384,10 @@ class Admin_Settings {
             // output checkbox and label with the format menu name (location(s))
             echo '<div><input type="checkbox" id="wap_menu_option" 
                 name="wawp_menu_location_name[]" value="' . 
-                esc_html__($menu_id) . '" ' . esc_html__($checked) . '>';
-            echo '<label for="' . esc_html__($menu_id) . '">' . 
-                esc_html__($menu->name) . ' (' . 
-                esc_html__($menu_id_to_location[$menu_id]) . 
+                esc_html($menu_id) . '" ' . esc_html($checked) . '>';
+            echo '<label for="' . esc_html($menu_id) . '">' . 
+                esc_html($menu->name) . ' (' . 
+                esc_html($menu_id_to_location[$menu_id]) . 
                 ')</label></div>';
 
         }
@@ -467,7 +467,7 @@ class Admin_Settings {
                 $status_checked = 'checked';
             }
             ?>
-            <input type="checkbox" name="wawp_restriction_status_name[]" class='wawp_class_status' value="<?php esc_html_e($status_key); ?>" <?php esc_html_e($status_checked); ?>/> <?php esc_html_e($status); ?> </input><br>
+            <input type="checkbox" name="wawp_restriction_status_name[]" class='wawp_class_status' value="<?php echo esc_html($status_key); ?>" <?php echo esc_html($status_checked); ?>/> <?php echo esc_html($status); ?> </input><br>
             <?php
         }
     }
@@ -576,13 +576,13 @@ class Admin_Settings {
                     }
                 }
                 ?>
-					<input type="checkbox" name="wawp_fields_name[]" class='wawp_case_field' value="<?php esc_html_e($field_id); ?>" <?php esc_html_e($is_checked); ?>/> <?php esc_html_e($field_name); ?> </input><br>
+					<input type="checkbox" name="wawp_fields_name[]" class='wawp_case_field' value="<?php echo esc_html($field_id); ?>" <?php echo esc_html($is_checked); ?>/> <?php echo esc_html($field_name); ?> </input><br>
 				<?php
             }
         } else { // no custom fields
             $authorization_link = esc_url(site_url() . '/wp-admin/admin.php?page=wawp-login');
             ?>
-            <p>Your WildApricot site does not have any contact fields! Please ensure that you have correctly entered your WildApricot site's credentials under <a href="<?php esc_html_e($authorization_link); ?>">WildApricot Press -> Authorization</a></p>
+            <p>Your WildApricot site does not have any contact fields! Please ensure that you have correctly entered your WildApricot site's credentials under <a href="<?php echo esc_html($authorization_link); ?>">WildApricot Press -> Authorization</a></p>
             <?php
         }
     }
@@ -644,7 +644,7 @@ class Admin_Settings {
                 }
             }
             ?>
-            <input type="checkbox" name="wawp_delete_name[]" class='wawp_class_delete' value="<?php esc_html_e($key); ?>" <?php esc_html_e($checked); ?>/> <?php esc_html_e($attribute); ?> </input><br>
+            <input type="checkbox" name="wawp_delete_name[]" class='wawp_class_delete' value="<?php echo esc_html($key); ?>" <?php echo esc_html($checked); ?>/> <?php echo esc_html($attribute); ?> </input><br>
             <p><b><br>Please note that this information will never be deleted from your WildApricot site, only your WordPress site, so you can always recover the deleted information from your WordPress site by re-syncing your WordPress site with your WildApricot site.
             So, don't worry - you are not permanently deleting information that you cannot recover later.</b></p>
             <?php
@@ -693,7 +693,7 @@ class Admin_Settings {
     public function logfile_option_input() {
         $checked = Log::can_debug();
         ?>
-        <input type="checkbox" name="<?php esc_html_e(Log::LOG_OPTION); ?>" class="wawp_class_logfile" value="checked" <?php esc_html_e($checked); ?>></input>
+        <input type="checkbox" name="<?php echo esc_html(Log::LOG_OPTION); ?>" class="wawp_class_logfile" value="checked" <?php echo esc_html($checked); ?>></input>
         <?php
     }
 
@@ -1575,7 +1575,7 @@ class License_Settings {
             $input_value = Addon::instance()::get_license($slug);
         } else {
         }
-        echo "<input id='license_key " . esc_html__($slug) . "' name='wawp_license_keys[" . esc_html__($slug) ."]' type='text' value='" . esc_html__($input_value) . "'  />" ;
+        echo "<input id='license_key " . esc_html($slug) . "' name='wawp_license_keys[" . esc_html($slug) ."]' type='text' value='" . esc_html($input_value) . "'  />" ;
         if ($license_valid) {
             echo "<br><p style='color:green;'><span class='dashicons dashicons-saved'></span> License key valid</p>";
         } 

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -335,7 +335,7 @@ class Admin_Settings {
                         break;
                     default:       $this->create_content_restriction_options_tab();
                     endswitch;
-                    ?>
+                ?>
             </div>
         </div>
         <?php
@@ -364,7 +364,7 @@ class Admin_Settings {
         $menus = wp_get_nav_menus();
         // array of menu ids => assigned locations
         $menu_id_to_location = flipped_menu_location_array();
-        Log::wap_log_debug(get_registered_nav_menus());
+        // Log::wap_log_debug(get_registered_nav_menus());
 
         // loop through list of menus
         foreach ($menus as $menu) {
@@ -384,8 +384,8 @@ class Admin_Settings {
             // output checkbox and label with the format menu name (location(s))
             echo '<div><input type="checkbox" id="wap_menu_option" 
                 name="wawp_menu_location_name[]" value="' . 
-                esc_html($menu_id) . '" ' . esc_html($checked) . '>';
-            echo '<label for="' . esc_html($menu_id) . '">' . 
+                esc_attr($menu_id) . '" ' . esc_attr($checked) . '>';
+            echo '<label for="' . esc_attr($menu_id) . '">' . 
                 esc_html($menu->name) . ' (' . 
                 esc_html($menu_id_to_location[$menu_id]) . 
                 ')</label></div>';
@@ -467,7 +467,7 @@ class Admin_Settings {
                 $status_checked = 'checked';
             }
             ?>
-            <input type="checkbox" name="wawp_restriction_status_name[]" class='wawp_class_status' value="<?php echo esc_html($status_key); ?>" <?php echo esc_html($status_checked); ?>/> <?php echo esc_html($status); ?> </input><br>
+            <input type="checkbox" name="wawp_restriction_status_name[]" class='wawp_class_status' value="<?php echo esc_attr($status_key); ?>" <?php echo esc_attr($status_checked); ?>/> <?php echo esc_html($status); ?> </input><br>
             <?php
         }
     }
@@ -541,7 +541,7 @@ class Admin_Settings {
             return empty_string_array($input);
         }
 		// Create valid variable that will hold the valid input
-		$valid = sanitize_textarea_field($input);
+		$valid = wp_kses_post($input);
         // Return valid input
         return $valid;
     }
@@ -576,13 +576,13 @@ class Admin_Settings {
                     }
                 }
                 ?>
-					<input type="checkbox" name="wawp_fields_name[]" class='wawp_case_field' value="<?php echo esc_html($field_id); ?>" <?php echo esc_html($is_checked); ?>/> <?php echo esc_html($field_name); ?> </input><br>
+					<input type="checkbox" name="wawp_fields_name[]" class='wawp_case_field' value="<?php echo esc_attr($field_id); ?>" <?php echo esc_attr($is_checked); ?>/> <?php echo esc_html($field_name); ?> </input><br>
 				<?php
             }
         } else { // no custom fields
             $authorization_link = esc_url(site_url() . '/wp-admin/admin.php?page=wawp-login');
             ?>
-            <p>Your WildApricot site does not have any contact fields! Please ensure that you have correctly entered your WildApricot site's credentials under <a href="<?php echo esc_html($authorization_link); ?>">WildApricot Press -> Authorization</a></p>
+            <p>Your WildApricot site does not have any contact fields! Please ensure that you have correctly entered your WildApricot site's credentials under <a href="<?php echo esc_url($authorization_link); ?>">WildApricot Press -> Authorization</a></p>
             <?php
         }
     }
@@ -644,7 +644,7 @@ class Admin_Settings {
                 }
             }
             ?>
-            <input type="checkbox" name="wawp_delete_name[]" class='wawp_class_delete' value="<?php echo esc_html($key); ?>" <?php echo esc_html($checked); ?>/> <?php echo esc_html($attribute); ?> </input><br>
+            <input type="checkbox" name="wawp_delete_name[]" class='wawp_class_delete' value="<?php echo esc_attr($key); ?>" <?php echo esc_attr($checked); ?>/> <?php echo esc_html($attribute); ?> </input><br>
             <p><b><br>Please note that this information will never be deleted from your WildApricot site, only your WordPress site, so you can always recover the deleted information from your WordPress site by re-syncing your WordPress site with your WildApricot site.
             So, don't worry - you are not permanently deleting information that you cannot recover later.</b></p>
             <?php
@@ -693,7 +693,7 @@ class Admin_Settings {
     public function logfile_option_input() {
         $checked = Log::can_debug();
         ?>
-        <input type="checkbox" name="<?php echo esc_html(Log::LOG_OPTION); ?>" class="wawp_class_logfile" value="checked" <?php echo esc_html($checked); ?>></input>
+        <input type="checkbox" name="<?php echo esc_attr(Log::LOG_OPTION); ?>" class="wawp_class_logfile" value="checked" <?php echo esc_html($checked); ?>></input>
         <?php
     }
 
@@ -1573,9 +1573,9 @@ class License_Settings {
         $license_valid = Addon::instance()::has_valid_license($slug);
         if ($license_valid) {
             $input_value = Addon::instance()::get_license($slug);
-        } else {
         }
-        echo "<input id='license_key " . esc_html($slug) . "' name='wawp_license_keys[" . esc_html($slug) ."]' type='text' value='" . esc_html($input_value) . "'  />" ;
+        
+        echo "<input id='license_key " . esc_attr($slug) . "' name='wawp_license_keys[" . esc_attr($slug) ."]' type='text' value='" . esc_attr($input_value) . "'  />" ;
         if ($license_valid) {
             echo "<br><p style='color:green;'><span class='dashicons dashicons-saved'></span> License key valid</p>";
         } 

--- a/src/class-activator.php
+++ b/src/class-activator.php
@@ -149,7 +149,7 @@ class Activator {
 		echo "<div class='notice notice-warning'><p>";
 		echo "Please enter your WildApricot credentials";
 		if (!is_wa_login_menu()) {
-			echo " in <a href=" . esc_html(get_auth_menu_url()) . ">WildApricot Press > Authorization</a>";
+			echo " in <a href=" . esc_url(get_auth_menu_url()) . ">WildApricot Press > Authorization</a>";
 		}
 		echo " in order to use the <strong>" . esc_html(CORE_NAME) . "</strong> functionality.";
 		echo "</p></div>";

--- a/src/class-activator.php
+++ b/src/class-activator.php
@@ -134,7 +134,7 @@ class Activator {
 		echo "<a href=" . esc_url(get_auth_menu_url()) . ">WildApricot credentials</a>";
 		echo " and ";
 		echo "<a href=" . esc_url(get_licensing_menu_url()) . "> license key</a>";
-		echo " in order to use the <strong>" . esc_html__(CORE_NAME) . "</strong> functionality.";
+		echo " in order to use the <strong>" . esc_html(CORE_NAME) . "</strong> functionality.";
 		echo "</p></div>";
 	}
 
@@ -149,9 +149,9 @@ class Activator {
 		echo "<div class='notice notice-warning'><p>";
 		echo "Please enter your WildApricot credentials";
 		if (!is_wa_login_menu()) {
-			echo " in <a href=" . esc_html__(get_auth_menu_url()) . ">WildApricot Press > Authorization</a>";
+			echo " in <a href=" . esc_html(get_auth_menu_url()) . ">WildApricot Press > Authorization</a>";
 		}
-		echo " in order to use the <strong>" . esc_html__(CORE_NAME) . "</strong> functionality.";
+		echo " in order to use the <strong>" . esc_html(CORE_NAME) . "</strong> functionality.";
 		echo "</p></div>";
 	}
 

--- a/src/class-addon.php
+++ b/src/class-addon.php
@@ -655,7 +655,7 @@ class Addon {
     public static function valid_license_key_notice($slug) {
         $plugin_name = self::get_title($slug);
         echo "<div class='notice notice-success is-dismissible license'><p>";
-		echo "Saved license key for <strong>" . esc_html__($plugin_name) . "</strong>.</p>";
+		echo "Saved license key for <strong>" . esc_html($plugin_name) . "</strong>.</p>";
 		echo "</div>";
     }
 
@@ -668,7 +668,7 @@ class Addon {
     public static function invalid_license_key_notice($slug) {
         $plugin_name = self::get_title($slug);
         echo "<div class='notice notice-error is-dismissible license'><p>";
-        echo "Your license key for <strong>" . esc_html__($plugin_name);
+        echo "Your license key for <strong>" . esc_html($plugin_name);
         echo "</strong> is invalid or expired. To get a new key please visit the <a href='https://newpathconsulting.com/wild-apricot-for-wordpress/'>WildApricot for Wordpress website</a>.";
         echo "</div>";
     }
@@ -683,7 +683,7 @@ class Addon {
         $plugin_name = self::get_title($slug);
         $filename = self::get_filename($slug);
         echo "<div class='notice notice-warning license'><p>";
-        echo "Please enter a valid license key for <strong>" . esc_html__($plugin_name) . "</strong>. </p></div>";
+        echo "Please enter a valid license key for <strong>" . esc_html($plugin_name) . "</strong>. </p></div>";
         // prevents printing "Plugin activated" message
         unset($_GET['activate']); 
     }
@@ -704,7 +704,7 @@ class Addon {
             echo " in <a href=" . esc_url(get_licensing_menu_url()) . ">WildApricot Press > Licensing</a>"; 
         }
         
-        echo " in order to use the <strong>" . esc_html__($plugin_name) . "</strong> functionality.</p></div>";
+        echo " in order to use the <strong>" . esc_html($plugin_name) . "</strong> functionality.</p></div>";
 
         unset($_GET['activate']);
     }

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -739,7 +739,7 @@ class WA_Integration {
 				}
 				?>
 					<li>
-						<input type="checkbox" name="wawp_membership_levels[]" class='wawp_case_level' value="<?php esc_html_e($membership_key); ?>" <?php esc_html_e($level_checked); ?>/> <?php esc_html_e($membership_level); ?> </input>
+						<input type="checkbox" name="wawp_membership_levels[]" class='wawp_case_level' value="<?php echo esc_html($membership_key); ?>" <?php echo esc_html($level_checked); ?>/> <?php echo esc_html($membership_level); ?> </input>
 					</li>
 				<?php
 			}
@@ -776,7 +776,7 @@ class WA_Integration {
 				}
 				?>
 					<li>
-						<input type="checkbox" name="wawp_membership_groups[]" class="wawp_case_group" value="<?php esc_html_e($membership_key); ?>" <?php esc_html_e($group_checked); ?>/> <?php esc_html_e($membership_group); ?> </input>
+						<input type="checkbox" name="wawp_membership_groups[]" class="wawp_case_group" value="<?php echo esc_html($membership_key); ?>" <?php echo esc_html($group_checked); ?>/> <?php echo esc_html($membership_group); ?> </input>
 					</li>
 				<?php
 			}
@@ -880,7 +880,7 @@ class WA_Integration {
 					<th><label>Account ID</label></th>
 					<td>
 					<?php
-						echo '<label>' . esc_html__($wa_account_id) . '</label>';
+						echo '<label>' . esc_html($wa_account_id) . '</label>';
 					?>
 					</td>
 				</tr>
@@ -889,7 +889,7 @@ class WA_Integration {
 					<th><label>Membership Level</label></th>
 					<td>
 					<?php
-						echo '<label>' . esc_html__($membership_level) . '</label>';
+						echo '<label>' . esc_html($membership_level) . '</label>';
 					?>
 					</td>
 				</tr>
@@ -898,7 +898,7 @@ class WA_Integration {
 					<th><label>User Status</label></th>
 					<td>
 					<?php
-						echo '<label>' . esc_html__($user_status) . '</label>';
+						echo '<label>' . esc_html($user_status) . '</label>';
 					?>
 					</td>
 				</tr>
@@ -907,7 +907,7 @@ class WA_Integration {
 					<th><label>Organization</label></th>
 					<td>
 					<?php
-						echo '<label>' . esc_html__($organization) . '</label>';
+						echo '<label>' . esc_html($organization) . '</label>';
 					?>
 					</td>
 				</tr>
@@ -916,7 +916,7 @@ class WA_Integration {
 					<th><label>Groups</label></th>
 					<td>
 					<?php
-						echo '<label>' . esc_html__($group_list) . '</label>';
+						echo '<label>' . esc_html($group_list) . '</label>';
 					?>
 					</td>
 				</tr>
@@ -938,10 +938,10 @@ class WA_Integration {
 						}
 						?>
 						<tr>
-							<th><label><?php esc_html_e($all_custom_fields[$custom_field]); ?></label></th>
+							<th><label><?php echo esc_html($all_custom_fields[$custom_field]); ?></label></th>
 							<td>
 							<?php
-								echo '<label>' . esc_html__($field_saved_value) . '</label>';
+								echo '<label>' . esc_html($field_saved_value) . '</label>';
 							?>
 							</td>
 						</tr>
@@ -1096,7 +1096,7 @@ class WA_Integration {
 			$current_wp_user_id = wp_insert_user($user_data); // returns user ID
 			// Show error if necessary
 			if (is_wp_error($current_wp_user_id)) {
-				esc_html_e($current_wp_user_id->get_error_message());
+				echo esc_html($current_wp_user_id->get_error_message());
 			}
 			// Set user's status of being added by the plugin to true
 			update_user_meta($current_wp_user_id, self::USER_ADDED_BY_PLUGIN, true);
@@ -1422,7 +1422,7 @@ class WA_Integration {
 					$url = $login_url;
 					$button_text = 'Log In';
 				}
-				$items .= '<li id="wawp_login_logout_button" class="menu-item menu-item-type-post_type menu-item-object-page"><a href="'. esc_url($url) .'">' . esc_html__($button_text) . '</a></li>';
+				$items .= '<li id="wawp_login_logout_button" class="menu-item menu-item-type-post_type menu-item-object-page"><a href="'. esc_url($url) .'">' . esc_html($button_text) . '</a></li>';
 			}
 		}
 		return $items;

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -436,11 +436,11 @@ class WA_Integration {
 		
 		// Append 'Log In' button and the styling div to the restriction message
 		$login_url = $this->get_login_link();
-		$restriction_message = '<div class="wawp_restriction_content_div">' . ($restriction_message);
+		$restriction_message = '<div class="wawp_restriction_content_div">' . wp_kses_post($restriction_message);
 
 		// Automatically restrict the post if user is not logged in
 		if (!is_user_logged_in()) {
-			$restriction_message .= '<li id="wawp_restriction_login_button"><a href="'. esc_url($login_url) .'">Log In</a></li>';
+			$restriction_message .= '<a id="wawp_restriction_login_button" href="'. esc_url($login_url) .'">Log In</a>';
 			$restriction_message .= '</div>';
 			return $restriction_message;
 		}
@@ -739,7 +739,7 @@ class WA_Integration {
 				}
 				?>
 					<li>
-						<input type="checkbox" name="wawp_membership_levels[]" class='wawp_case_level' value="<?php echo esc_html($membership_key); ?>" <?php echo esc_html($level_checked); ?>/> <?php echo esc_html($membership_level); ?> </input>
+						<input type="checkbox" name="wawp_membership_levels[]" class='wawp_case_level' value="<?php echo esc_attr($membership_key); ?>" <?php echo esc_attr($level_checked); ?>/> <?php echo esc_html($membership_level); ?> </input>
 					</li>
 				<?php
 			}
@@ -776,7 +776,7 @@ class WA_Integration {
 				}
 				?>
 					<li>
-						<input type="checkbox" name="wawp_membership_groups[]" class="wawp_case_group" value="<?php echo esc_html($membership_key); ?>" <?php echo esc_html($group_checked); ?>/> <?php echo esc_html($membership_group); ?> </input>
+						<input type="checkbox" name="wawp_membership_groups[]" class="wawp_case_group" value="<?php echo esc_attr($membership_key); ?>" <?php echo esc_attr($group_checked); ?>/> <?php echo esc_html($membership_group); ?> </input>
 					</li>
 				<?php
 			}

--- a/src/wap-exception.php
+++ b/src/wap-exception.php
@@ -80,7 +80,7 @@ abstract class Exception extends \Exception {
         echo "<div class='notice notice-error wawp-exception'>";
         echo "<h3>FATAL ERROR</h3>";
         echo "<p>WildApricot Press has encountered an error with ";
-        esc_html_e($error_type);
+        echo esc_html($error_type);
         echo " and functionality must be disabled. Please correct the error so the plugin can continue. ";
         echo "More details can be found in the log file located in your WordPress directory in <code>wp-content/wapdebug.log</code>.</p>";
         echo "<p>Contact the <a href='https://talk.newpathconsulting.com/'>NewPath Consulting team</a> for support.</p>";

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,7 +7,7 @@ require_once plugin_dir_path(__FILE__) . 'src/helpers.php';
 require_once plugin_dir_path(__FILE__) . 'src/wap-exception.php';
 
 if (!defined('WP_UNINSTALL_PLUGIN')) {
-	wp_die(sprintf(__('%s should only be called when uninstalling the plugin.', WAWP\CORE_SLUG), __FILE__ ));
+	wp_die(sprintf('%s should only be called when uninstalling the plugin.', __FILE__ ));
 	exit;
 }
 


### PR DESCRIPTION
Resolves #81 
- Pull commits from [HTTP API fix](https://github.com/NewPath-Consulting/Wild-Apricot-Press/tree/80-use-http-api)
- Replace translation+escaping functions with escaping functions
- Use appropriate escaping functions (e.g. `esc_attr` instead of `esc_html` for HTML attributes)
- Fix sanitization/escaping for global restriction message -- previously was not preserving html tags