### PR TITLE
Menu button setting enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tags: wap, wildapricot, wild apricot, sso, membership
 Requires at least: 5.0
 Tested up to: 6.0
 Requires PHP: 7.4
-Stable Tag: 1.0.0
+Stable Tag: 1.0b5
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/css/wawp-styles-admin.css
+++ b/css/wawp-styles-admin.css
@@ -5,16 +5,23 @@
 	}
 }
 
-.loginChild {
-	flex: 1;
-}
-
-.loginChild:first-child {
-	margin-right: 20px;
-}
-
-.errorAlert {
+.wap-error, .wap-exception {
 	color: red;
+}
+
+.wap-success {
+	color: green;
+}
+
+/* Width for WA authorization credentials input boxes */
+.wap-wa-auth-creds {
+	width: 75%;
+}
+
+@media only screen and (max-width: 1200px) {
+	.wap-wa-auth-creds {
+		width: 100%;
+	}
 }
 
 #wawp_restricted_message_textarea {
@@ -44,38 +51,6 @@
 ul.wawp_list {
 	list-style-type: disc;
 	margin-left: 5%;
-}
-
-/* Formatting for the API Key, Client ID, and Client Secret inputs */
-#wawp_wal_api_key {
-	width: 80%;
-}
-
-#wawp_wal_client_id {
-	width: 80%;
-}
-
-#wawp_wal_client_secret {
-	width: 80%;
-}
-
-@media only screen and (max-width: 1200px) {
-	#wawp_wal_api_key {
-		width: 100%;
-	}
-
-	#wawp_wal_client_id {
-		width: 100%;
-	}
-
-	#wawp_wal_client_secret {
-		width: 100%;
-	}
-}
-
-.wawp_authorization_img {
-	max-width: 500px;
-	width: 100%;
 }
 
 .form-table th {

--- a/plugin.php
+++ b/plugin.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Plugin Name:       WildApricot Press (WAP)
+ * Plugin Name:       WildApricot Press
  * Plugin URI:        https://newpathconsulting.com/wap
  * Description:       Integrates your WildApricot-powered organization with a WordPress website! Powered by WildApricot's API.
  * Version:           1.0b5

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -351,6 +351,16 @@ class Admin_Settings {
     }
 
     /**
+     * Inform user there are no menus so the login button location cannot be
+     * chose.
+     *
+     * @return void
+     */
+    public function login_menu_location_no_menus_info() {
+        print 'You must have at least one menu added to your WordPress site.';
+    }
+
+    /**
      * Display the checkboxes corresponding to each visible menu on the site
      * for the user to choose from to place the WA user login button
      * 
@@ -736,6 +746,19 @@ class Admin_Settings {
             $register_args // Sanitize
         );
 
+        // if menus are empty, display separate message and don't add fields
+        $menus = wp_get_nav_menus();
+        if (empty($menus)) {
+            // Create settings section
+            add_settings_section(
+                'wawp_menu_location_id', // ID
+                'Login/Logout Button Menu Location', // Title
+                array( $this, 'login_menu_location_no_menus_info' ), // Callback
+                self::LOGIN_BUTTON_LOCATION_PAGE // Page
+            );
+            return;
+        }
+
         // Create settings section
         add_settings_section(
             'wawp_menu_location_id', // ID
@@ -937,7 +960,11 @@ class Admin_Settings {
             // This prints out all hidden setting fields
             settings_fields( self::LOGIN_BUTTON_LOCATION_SECTION );
             do_settings_sections( self::LOGIN_BUTTON_LOCATION_PAGE );
-            submit_button();
+            $menus = wp_get_nav_menus();
+            if (!empty($menus)) {
+                // don't display submit button if there are no menus
+                submit_button();
+            }
         ?>
         </form>
         <!-- Check if menu location(s) have been submitted -->

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -217,7 +217,7 @@ class Settings {
     }
 
     /**
-     * Add WAP settings page page.
+     * Add WAP settings page.
      * 
      * @return void.
      */
@@ -410,7 +410,7 @@ class Admin_Settings {
             echo '<label for="' . esc_attr($menu_id) . '">' . 
                 esc_html($display_name);
             if (!$menu_has_location && $is_checked) {
-                echo '<span style="color:red;"> (Menu not assigned to a location)</span>';
+                echo '<span class="wap-error"> (Menu not assigned to a location)</span>';
             }
             echo '</label></div>';
 
@@ -981,19 +981,6 @@ class Admin_Settings {
             }
         ?>
         </form>
-        <!-- Check if menu location(s) have been submitted -->
-        <?php
-            // // Check menu locations in options table
-            // $menu_location_saved = get_option(WA_Integration::MENU_LOCATIONS_KEY);
-            // // If menu locations is not empty, then it has been saved
-            // if (!empty($menu_location_saved)) {
-            //     // Display success statement
-            //     echo '<p style="color:green">Menu Location(s) for the Login/Logout button have been saved!</p>';
-            // } else {
-            //     Log::wap_log_warning('No menu location for the login/logout button selected. Please select so the button will appear on your site.');
-            //     echo '<p style="color:red">Missing Menu Location(s) for the Login/Logout button! Please check off your desired menu locations above!</p>';
-            // }
-        ?>
         <!-- Form for Restriction Status(es) -->
         <form method="post" action="options.php">
         <?php
@@ -1197,11 +1184,11 @@ class WA_Auth_Settings {
                         }
 						if (!WA_Integration::valid_wa_credentials()) { 
                             // not valid
-							echo '<p style="color:red">Missing valid WildApricot credentials. Please enter them above.</p>';
+							echo '<p class="wap-error">Missing valid WildApricot credentials. Please enter them above.</p>';
 						} else if ($wild_apricot_url) { 
                             // successful login
-							echo '<p style="color:green">Valid WildApricot credentials have been saved.</p>';
-                            echo '<p style="color:green">Your WordPress site has been connected to <b>' . esc_url($wild_apricot_url) . '</b>.</p>';
+							echo '<p class="wap-success">Valid WildApricot credentials have been saved.</p>';
+                            echo '<p class="wap-success">Your WordPress site has been connected to <b>' . esc_url($wild_apricot_url) . '</b>.</p>';
 						}
                         return;
 					?>
@@ -1276,11 +1263,11 @@ class WA_Auth_Settings {
      * @return void
      */
     public function api_key_callback() {
-		echo "<input id='wawp_wal_api_key' name='wawp_wal_name[wawp_wal_api_key]'
-			type='text' placeholder='*************' />";
+		echo '<input class="wap-wa-auth-creds" id="wawp_wal_api_key" name="wawp_wal_name[wawp_wal_api_key]"
+			type="text" placeholder="*************" />';
 		// Check if api key has been set; if so, echo that the client secret has been set!
 		if (!empty($this->options[WA_Integration::WA_API_KEY_OPT]) && !Exception::fatal_error()) {
-			echo "<p>API Key is set</p>";
+			echo '<p>API Key is set</p>';
 		}
     }
 
@@ -1290,11 +1277,11 @@ class WA_Auth_Settings {
      * @return void
      */
     public function client_id_callback() {
-		echo "<input id='wawp_wal_client_id' name='wawp_wal_name[wawp_wal_client_id]'
-			type='text' placeholder='*************' />";
+		echo '<input class="wap-wa-auth-creds" id="wawp_wal_client_id" name="wawp_wal_name[wawp_wal_client_id]"
+			type="text" placeholder="*************" />';
 		// Check if client id has been set; if so, echo that the client secret has been set!
 		if (!empty($this->options[WA_Integration::WA_CLIENT_ID_OPT]) && !Exception::fatal_error()) {
-			echo "<p>Client ID is set</p>";
+			echo '<p>Client ID is set</p>';
 		}
     }
 
@@ -1304,11 +1291,11 @@ class WA_Auth_Settings {
      * @return void
      */
     public function client_secret_callback() {
-		echo "<input id='wawp_wal_client_secret' name='wawp_wal_name[wawp_wal_client_secret]'
-			type='text' placeholder='*************' />";
+		echo '<input class="wap-wa-auth-creds" id="wawp_wal_client_secret" name="wawp_wal_name[wawp_wal_client_secret]"
+			type="text" placeholder="*************" />';
 		// Check if client secret has been set; if so, echo that the client secret has been set!
 		if (!empty($this->options[WA_Integration::WA_CLIENT_SECRET_OPT]) && !Exception::fatal_error()) {
-			echo "<p>Client Secret is set</p>";
+			echo '<p>Client Secret is set</p>';
 		}
     }
 
@@ -1616,9 +1603,9 @@ class License_Settings {
             $input_value = Addon::instance()::get_license($slug);
         }
         
-        echo "<input id='license_key " . esc_attr($slug) . "' name='wawp_license_keys[" . esc_attr($slug) ."]' type='text' value='" . esc_attr($input_value) . "'  />" ;
+        echo '<input id="license_key "' . esc_attr($slug) . '" name="wawp_license_keys[' . esc_attr($slug) .']" type="text" value="' . esc_attr($input_value) . '"  />' ;
         if ($license_valid) {
-            echo "<br><p style='color:green;'><span class='dashicons dashicons-saved'></span> License key valid</p>";
+            echo '<br><p class="wap-success"><span class="dashicons dashicons-saved"></span> License key valid</p>';
         } 
     }
 }

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -374,15 +374,11 @@ class Admin_Settings {
         $menus = wp_get_nav_menus();
         // array of menu ids => assigned locations
         $menu_id_to_location = flipped_menu_location_array();
-        // Log::wap_log_debug(get_registered_nav_menus());
 
         // loop through list of menus
         foreach ($menus as $menu) {
             $menu_id = $menu->term_id;
-            if (!array_key_exists($menu_id, $menu_id_to_location)) {
-                // if menu is not assigned to a location, it's not present on the site, skip it
-                continue;
-            }
+            $display_name = $menu->name;
 
             // if menu is saved in options, check the input box
             $is_checked = in_array($menu_id, $saved_login_menu);
@@ -391,14 +387,32 @@ class Admin_Settings {
                 $checked = 'checked';
             }
 
+            $menu_has_location = array_key_exists($menu_id, $menu_id_to_location);
+
+            // if menu has a location, display it
+            if ($menu_has_location) {
+                $display_name = $display_name . ' (' . $menu_id_to_location[$menu_id] . ')';
+            } else if (!empty($menu_id_to_location) && !$is_checked) {
+                /**
+                 * if menu does not have locations but there are other menus 
+                 * registered to locations AND the menu is not currently 
+                 * selected, don't display it
+                 */
+                continue;
+            }
+            // if no menus have locations, display all of them
+
+
             // output checkbox and label with the format menu name (location(s))
             echo '<div><input type="checkbox" id="wap_menu_option" 
                 name="wawp_menu_location_name[]" value="' . 
                 esc_attr($menu_id) . '" ' . esc_attr($checked) . '>';
             echo '<label for="' . esc_attr($menu_id) . '">' . 
-                esc_html($menu->name) . ' (' . 
-                esc_html($menu_id_to_location[$menu_id]) . 
-                ')</label></div>';
+                esc_html($display_name);
+            if (!$menu_has_location && $is_checked) {
+                echo '<span style="color:red;"> (Menu not assigned to a location)</span>';
+            }
+            echo '</label></div>';
 
         }
     }

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -357,7 +357,9 @@ class Admin_Settings {
      * @return void
      */
     public function login_menu_location_no_menus_info() {
-        print 'You must have at least one menu added to your WordPress site.';
+        print '<p class="wap-error"><strong>Please add at least one menu in <a href=' . 
+                esc_url(admin_url('nav-menus.php')) . '>Appearance > Menus</a> in 
+                order to display the Login/Logout button on your website.</strong></p>';
     }
 
     /**

--- a/src/class-activator.php
+++ b/src/class-activator.php
@@ -134,13 +134,13 @@ class Activator {
 	 * @return void
 	 */
 	private static function empty_creds_message() {
-		echo "<div class='notice notice-warning'><p>";
-		echo "Please enter your ";
-		echo "<a href=" . esc_url(get_auth_menu_url()) . ">WildApricot credentials</a>";
-		echo " and ";
-		echo "<a href=" . esc_url(get_licensing_menu_url()) . "> license key</a>";
-		echo " in order to use the <strong>" . esc_html(CORE_NAME) . "</strong> functionality.";
-		echo "</p></div>";
+		echo '<div class="notice notice-warning"><p>';
+		echo 'Please enter your ';
+		echo '<a href=' . esc_url(get_auth_menu_url()) . '>WildApricot credentials</a>';
+		echo ' and ';
+		echo '<a href=' . esc_url(get_licensing_menu_url()) . '> license key</a>';
+		echo ' in order to use the <strong>' . esc_html(CORE_NAME) . '</strong> functionality.';
+		echo '</p></div>';
 	}
 
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -168,8 +168,31 @@ function disable_core() {
  * primary menu name of the current theme.
  */
 function get_primary_menu() {
-    $menu_locations = get_nav_menu_locations();
-    return min($menu_locations);
+    $nav_menu_locations = get_nav_menu_locations();
+
+    // remove empty locations (0 means empty)
+    $nav_menu_locations = array_filter($nav_menu_locations, function($loc) {
+        return $loc;
+    });
+
+    // if there are no menus registered in locations, use menu list
+    if (empty($nav_menu_locations)) return get_primary_menu_from_menu_list();
+
+    // find primary menu
+    $min_menu = min($nav_menu_locations);
+    return $min_menu;
+}
+
+function get_primary_menu_from_menu_list() {
+    $menus = wp_get_nav_menus();
+
+    // use array_reduce to find the minimum term ID
+    $primary_menu = array_reduce($menus, function($menu1, $menu2) {
+        if ($menu1->term_id < $menu2->term_id) return $menu1;
+        else return $menu2;
+    }, $menus[0]);
+
+    return $primary_menu->term_id;
 }
 
 /**
@@ -194,7 +217,8 @@ function get_login_menu_location() {
 
 /**
  * Returns menu location array with keys and values flipped. So the menus 
- * correspond to their assigned locations.
+ * correspond to their assigned locations. Returns an empty array if no
+ * locations have menus assigned.
  *
  * @return array 
  */
@@ -205,6 +229,10 @@ function flipped_menu_location_array() {
 
     foreach ($menu_locations as $location => $menu_id) {
         $location_name = $location_names[$location];
+
+        // if location does not have any menus, do not add it
+        if (!$menu_id) continue;
+
         if (!array_key_exists($menu_id, $flipped_array)) {
             // if menu doesn't exist yet, add it
             $flipped_array[$menu_id] = $location_name;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -164,8 +164,12 @@ function disable_core() {
 }
 
 /**
- * @return array an array containing a single element corresponding to the
- * primary menu name of the current theme.
+ * Retrieves the primary menu ID by finding the menu with the lowest ID number
+ * in the locations to menus list.
+ * If there are no menus assigned to locations, finds the primary menu by
+ * searching through the list of all menus.
+ * 
+ * @return int the ID of the primary menu
  */
 function get_primary_menu() {
     $nav_menu_locations = get_nav_menu_locations();
@@ -183,6 +187,11 @@ function get_primary_menu() {
     return $min_menu;
 }
 
+/**
+ * Retrieves the ID of the primary menu found in the list of all menus.
+ * 
+ * @return int primary menu ID
+ */
 function get_primary_menu_from_menu_list() {
     $menus = wp_get_nav_menus();
 
@@ -200,12 +209,21 @@ function get_primary_menu_from_menu_list() {
  * If the menu location is not saved in the options table, returns the primary
  * menu.
  * 
- * @return array an array containing a single element corresponding to the
- * primary menu name of the current theme.
+ * @return array array of the selected menu(s) in which to place the login
+ * buttton.
  */
 function get_login_menu_location() {
     // retrieve set menu location from the options table
     $wawp_wal_login_logout_button = get_option(WA_Integration::MENU_LOCATIONS_KEY, []);
+
+    // check that saved menus still exist
+    foreach ($wawp_wal_login_logout_button as $i => $menu_id) {
+        $menu_exists = wp_get_nav_menu_object($menu_id);
+        // if menu no longer exists, remove it
+        if (!$menu_exists) {
+            unset($wawp_wal_login_logout_button[$i]);
+        }
+    }
 
     // if empty, then get the primary menu as a default
     if (empty($wawp_wal_login_logout_button)) {

--- a/src/wap-exception.php
+++ b/src/wap-exception.php
@@ -63,9 +63,9 @@ abstract class Exception extends \Exception {
     protected abstract function get_error_type();
 
     public static function get_user_facing_error_message() {
-        return "<div class='wawp-exception' style='color:red'>
+        return '<div class="wap-exception">
         <h3>FATAL ERROR</h3><p>WildApricot Press has encountered a fatal error and must be disabled.
-        Please contact your site administrator.</p></div>";
+        Please contact your site administrator.</p></div>';
     }
 
     /**
@@ -77,7 +77,7 @@ abstract class Exception extends \Exception {
      * @return void
      */
     public static function admin_notice_error_message_template($error_type) {
-        echo "<div class='notice notice-error wawp-exception'>";
+        echo "<div class='notice notice-error wap-exception'>";
         echo "<h3>FATAL ERROR</h3>";
         echo "<p>WildApricot Press has encountered an error with ";
         echo esc_html($error_type);


### PR DESCRIPTION
Closes #83 

- If there are no menus with assigned locations, all menus will be displayed
- If a selected menu is assigned to a location when it previously had none, it will remain checked
  - Checkbox will now display assigned location in parentheses
- If a selected menu is **unassigned** from a location when it previously had one OR when no menus have locations and a menu is selected by default it will display "Menu not assigned to a location" in red text next to the menu name
- When menu name or location changes
  - Nothing happens on the backend since the setting is controlled by menu IDs
  - Only the checkbox display text will change
  - Menu and login button move to the appropriate location
- When a menu has been deleted
  - Next lowest indexed menu will be selected by default