### PR TITLE
Reset license when WA authorization credentials change

### DIFF
--- a/css/wawp-styles-admin.css
+++ b/css/wawp-styles-admin.css
@@ -18,9 +18,17 @@
 	width: 75%;
 }
 
+.license_key {
+	width: 20%;
+}
+
 @media only screen and (max-width: 1200px) {
 	.wap-wa-auth-creds {
 		width: 100%;
+	}
+	
+	.license_key {
+		width: 20%;
 	}
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -1,10 +1,15 @@
 (function($) {
     $(document).ready(function() {
+
         const LEVELS_SELECT_ALL = '#wawp_check_all_levels';
         const LEVELS_CHECKBOXES = '.wawp_case_level';
 
         const GROUPS_SELECT_ALL = '#wawp_check_all_groups';
         const GROUPS_CHECKBOXES = '.wawp_case_group';
+
+        // on page load, select 'select all' box if all checkboxes are selected
+        toggle_select_all_check(LEVELS_SELECT_ALL, LEVELS_CHECKBOXES);
+        toggle_select_all_check(GROUPS_SELECT_ALL, GROUPS_CHECKBOXES);
         
         // Check/uncheck all levels
         $(LEVELS_SELECT_ALL).click(function () {
@@ -22,6 +27,7 @@
         $(LEVELS_CHECKBOXES).click(function() {
             toggle_select_all_check(LEVELS_SELECT_ALL, LEVELS_CHECKBOXES);
         });
+
         // Groups
         $(GROUPS_CHECKBOXES).click(function() {
             toggle_select_all_check(GROUPS_SELECT_ALL, GROUPS_CHECKBOXES);

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -1222,9 +1222,9 @@ class WA_Auth_Settings {
             if (!$valid) {
                 return empty_string_array($input);
             }
+
             $api_key = $valid[WA_Integration::WA_API_KEY_OPT];
             $valid_api = WA_API::is_application_valid($api_key); 
-
             // credentials invalid
             if (!$valid_api) {
                 return empty_string_array($input);

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -1233,17 +1233,23 @@ class WA_Auth_Settings {
 
             // encrypt valid credentials
             $data_encryption = new Data_Encryption();
+            $saved_auth_creds = WA_API::load_user_credentials();
+            $auth_creds_changed = false;
             foreach ($valid as $key => $value) {
+                if ($valid[$key] != $saved_auth_creds[$key]) {
+                    $auth_creds_changed = true;
+                }
                 $valid[$key] = $data_encryption->encrypt($value);
+
             }
         } catch (Exception $e) {
             Log::wap_log_error($e->getMessage(), true);
             return empty_string_array($input);
         } 
 
-        // Schedule CRON update for updating the available membership levels and groups
-        Settings::setup_cron_job();
-        update_option(Addon::WAWP_DISABLED_OPTION, false);
+        if ($auth_creds_changed) {
+            Addon::wa_auth_changed_update_status();
+        }
 
         // Return array of valid inputs
         return $valid;

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -1385,6 +1385,7 @@ class WA_Auth_Settings {
         $wild_apricot_url = esc_url_raw($wild_apricot_url_array['Url']);
         $wild_apricot_url_enc = $data_encryption->encrypt($wild_apricot_url);
 
+        $wawp_api_instance->retrieve_custom_fields();
 
         // Save transients and options all at once; by this point all values should be valid.
         // Store access token and account ID as transients

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -1362,7 +1362,6 @@ class WA_Auth_Settings {
      * @return void
      */
     private static function obtain_and_save_wa_data_from_api($valid_api) {
-        // $valid_api = WA_API::is_application_valid($api_key); 
         $data_encryption = new Data_Encryption();
         // Extract access token and ID, as well as expiring time
         $access_token = $valid_api['access_token'];
@@ -1612,7 +1611,7 @@ class License_Settings {
             $input_value = Addon::instance()::get_license($slug);
         }
         
-        echo '<input id="license_key "' . esc_attr($slug) . '" name="wawp_license_keys[' . esc_attr($slug) .']" type="text" value="' . esc_attr($input_value) . '"  />' ;
+        echo '<input class="license_key" id="' . esc_attr($slug) . '" name="wawp_license_keys[' . esc_attr($slug) .']" type="text" value="' . esc_attr($input_value) . '"  />' ;
         if ($license_valid) {
             echo '<br><p class="wap-success"><span class="dashicons dashicons-saved"></span> License key valid</p>';
         } 

--- a/src/class-addon.php
+++ b/src/class-addon.php
@@ -447,9 +447,10 @@ class Addon {
 
     /**
      * Disables plugins. 
-     * If the slug is the core plugin, all NewPath addons will be disabled along with the core plugin.
-     * If the slug is an addon, disable_addon will be called.
-     * Make login page private and prevent uses from accessing the login form
+     * If the slug is the core plugin, all NewPath addons will be disabled along
+     * with the core plugin. If the slug is an addon, `disable_addon` will be
+     * called. Make login page private and prevent uses from accessing the 
+     * login form
      * 
      * @param string $slug slug string of the plugin to disable.
      * @param string $new_license_status new, accurate status for the license.
@@ -487,9 +488,37 @@ class Addon {
         }
 
         WA_Integration::delete_transients();
+
+        Addon::unschedule_all_cron_jobs();
         
         do_action('remove_wa_integration');
 
+    }
+
+    /**
+     * Unschedules all CRON jobs scheduled by the plugin.
+     *
+     * @return void
+     */
+    public static function unschedule_all_cron_jobs() {
+		Addon::unschedule_cron_job(Settings::CRON_HOOK);
+		Addon::unschedule_cron_job(WA_Integration::USER_REFRESH_HOOK);
+		Addon::unschedule_cron_job(WA_Integration::LICENSE_CHECK_HOOK);
+    }
+
+    /**
+	 * Unschedules CRON job.
+	 * 
+	 * @param string $cron_hook_name cron job to remove
+	 * @return void
+	 */
+	private static function unschedule_cron_job($cron_hook_name) {
+		// Get the timestamp for the next event.
+		$timestamp = wp_next_scheduled($cron_hook_name);
+		// Check that event is already scheduled
+		if ($timestamp) {
+			wp_unschedule_event($timestamp, $cron_hook_name);
+		}
     }
 
     /**
@@ -614,10 +643,11 @@ class Addon {
     }
 
     /**
-     * Checks the Integromat hook response for the necessary conditions for a valid license.
+     * Checks the Integromat hook response for the necessary conditions for a 
+     * valid license.
      * Must have WAP in products.
      * Must have correct URL and user ID for their WA account associated with
-     * the API credentials
+     * the API credentials.
      * Must not be expired.
      * 
      * @return bool true if above conditions are valid, false if not.

--- a/src/class-addon.php
+++ b/src/class-addon.php
@@ -160,7 +160,7 @@ class Addon {
      */
     public static function new_addon($addon) {
         $option = get_option('wawp_addons');
-        if ($option == false) {
+        if (!$option) {
             $option = array();
         }
 
@@ -178,17 +178,7 @@ class Addon {
 
         self::$license_check_options[$slug] = $addon['license_check_option'];
         self::$addon_list[$slug] = $option[$slug];
-        self::update_addons($option);
-    }
-
-    /**
-     * Updates the addon list in the options table.
-     *
-     * @param string[] $new_list updated list of addons
-     * @return void
-     */
-    public static function update_addons($new_list) {
-        update_option(self::WAWP_ADDON_LIST_OPTION, $new_list);
+        update_option(self::WAWP_ADDON_LIST_OPTION, $option);
     }
 
     /**
@@ -728,9 +718,12 @@ class Addon {
 
     /**
      * Prints out a message prompting the user to enter their license key.
-     * Called when user has activated the plugin but has NOT YET entered their license key.
+     * Called when user has activated the plugin but has NOT YET entered their 
+     * license key.
      * 
      * @param string $slug slug of the plugin for which to display this prompt
+     * @param bool $is_licensing_page whether the user is currently on the
+     * license settings page or not
      * @param void
      */
     public static function license_key_prompt($slug, $is_licensing_page) {
@@ -738,6 +731,7 @@ class Addon {
 
         echo "<div class='notice notice-warning is-dismissable license'><p>";
         echo "Please enter your license key";
+        // if the user is not on the license settings, print the url
         if (!$is_licensing_page) {
             echo " in <a href=" . esc_url(get_licensing_menu_url()) . ">WildApricot Press > Licensing</a>"; 
         }

--- a/src/class-deactivator.php
+++ b/src/class-deactivator.php
@@ -31,10 +31,7 @@ class Deactivator {
 			wp_update_post($login_page);
 		}
 
-		// Unschedule the CRON events
-		WA_API::unsetCronJob(Settings::CRON_HOOK);
-		WA_API::unsetCronJob(WA_Integration::USER_REFRESH_HOOK);
-		WA_API::unsetCronJob(WA_Integration::LICENSE_CHECK_HOOK);
+		Addon::unschedule_all_cron_jobs();
 	}
 }
 ?>

--- a/src/class-wa-api.php
+++ b/src/class-wa-api.php
@@ -55,19 +55,28 @@ class WA_API {
 	/**
 	 * Converts the API response to the body from which data can be extracted
 	 *
-	 * @param  array $response holds the output from the API request, organized in a key-value pattern
-	 * @return array|bool $data is the body of the response, false if unauthorized
+	 * @param array $response holds the output from the API request, organized
+	 *  in a key-value pattern
+	 * @return array|bool $data is the body of the response, empty array if
+	 * unauthorized
 	 * @throws API_Exception
 	 */
     private static function response_to_data($response) {
         if (is_wp_error($response)) {
 			throw new API_Exception(API_Exception::api_connection_error());
 		}
-		if ($response['response']['code'] == '401') return false;
+
+		// if user is unauthorized, return empty array
+		if ($response['response']['code'] == '401') 
+		{
+			return array();
+		} 
+
 		// Get body of response
 		$body = wp_remote_retrieve_body($response);
 		// Get data from json response
 		$data = json_decode($body, true);
+
 		// Check if there is an error in body
 		if (isset($data['error'])) { // error in body
 			throw new API_Exception(API_Exception::api_response_error());

--- a/src/class-wa-api.php
+++ b/src/class-wa-api.php
@@ -24,9 +24,11 @@ class WA_API {
     private $wa_user_id;
 
 	/**
-	 * Creates instance of class based on the user's access token and WildApricot user ID
+	 * Creates instance of class based on the user's access token and 
+	 * WildApricot user ID
 	 *
-	 * @param string $access_token is the user's access token obtained from the WildApricot API
+	 * @param string $access_token is the user's access token obtained from the
+	 * WildApricot API
 	 * @param string $wa_user_id is the user's WildApricot ID
 	 */
     public function __construct($access_token, $wa_user_id) {
@@ -35,21 +37,6 @@ class WA_API {
 		// Include WA_Integration and Data_Encryption
 		require_once('class-wa-integration.php');
 		require_once('class-data-encryption.php');
-    }
-
-	/**
-	 * Removes CRON job.
-	 * 
-	 * @param string $cron_hook_name cron job to remove
-	 * @return void
-	 */
-	public static function unsetCronJob($cron_hook_name) {
-		// Get the timestamp for the next event.
-		$timestamp = wp_next_scheduled($cron_hook_name);
-		// Check that event is already scheduled
-		if ($timestamp) {
-			wp_unschedule_event($timestamp, $cron_hook_name);
-		}
     }
 
 	/**
@@ -128,7 +115,8 @@ class WA_API {
 
 	/**
 	 * Checks if a new admin access token is required and returns a valid access
-	 * token. If there are any encryption or decryption exceptions, an empty array will be returned.
+	 * token. If there are any encryption or decryption exceptions, an empty 
+	 * array will be returned.
 	 *
 	 * @return array $verified_data holds the verified access token and account ID
 	 */
@@ -156,8 +144,17 @@ class WA_API {
 			$new_access_token_enc = $dataEncryption->encrypt($new_access_token);
 			$new_account_id_enc = $dataEncryption->encrypt($new_account_id);
 			
-			set_transient(WA_Integration::ADMIN_ACCESS_TOKEN_TRANSIENT, $new_access_token_enc, $new_expiring_time);
-			set_transient(WA_Integration::ADMIN_ACCOUNT_ID_TRANSIENT, $new_account_id_enc, $new_expiring_time);
+			set_transient(
+				WA_Integration::ADMIN_ACCESS_TOKEN_TRANSIENT, 
+				$new_access_token_enc, 
+				$new_expiring_time
+			);
+
+			set_transient(
+				WA_Integration::ADMIN_ACCOUNT_ID_TRANSIENT, 
+				$new_account_id_enc, 
+				$new_expiring_time
+			);
 			// Update values
 			$access_token = $new_access_token;
 			$wa_account_id = $new_account_id;
@@ -224,13 +221,19 @@ class WA_API {
 	public function retrieve_custom_fields() {
 		// Make API request for custom fields
 		$args = $this->request_data_args();
-		$url = self::API_URL . self::ADMIN_API_VERSION . '/accounts/' . $this->wa_user_id . '/contactfields?showSectionDividers=true';
+		$url = self::API_URL . self::ADMIN_API_VERSION . '/accounts/' . 
+			$this->wa_user_id . '/contactfields?showSectionDividers=true';
 		$response_api = wp_remote_get($url, $args);
 		$custom_field_response = self::response_to_data($response_api);
 
 		// Loop through custom fields and get field names with IDs
 		// Array that holds default fields
-		$default_fields = array('Group participation', 'User ID', 'Organization', 'Membership status');
+		$default_fields = array(
+			'Group participation', 
+			'User ID', 
+			'Organization', 
+			'Membership status'
+		);
 		// Do not add 'Group participation' or 'User ID' because those are already used by default
 		$custom_fields = array();
 		if (!empty($custom_field_response)) {
@@ -270,7 +273,10 @@ class WA_API {
 			// Get user email
 			$user_email = $wa_user->data->user_email;
 			// Get WildApricot ID
-			$wa_synced_id = get_user_meta($site_user_id, WA_Integration::WA_USER_ID_KEY);
+			$wa_synced_id = get_user_meta(
+				$site_user_id, 
+				WA_Integration::WA_USER_ID_KEY
+			);
 			$wa_synced_id = $wa_synced_id[0];
 			// Save to email to array indexed by WordPress ID
 			$user_emails_array[$site_user_id] = $user_email;
@@ -283,7 +289,8 @@ class WA_API {
 		}
 		// Make API request
 		$args = $this->request_data_args();
-		$url = self::API_URL . self::ADMIN_API_VERSION . '/accounts/' . $this->wa_user_id . '/contacts?%24async=false&%24' . $filter_string;
+		$url = self::API_URL . self::ADMIN_API_VERSION . '/accounts/' . 
+			$this->wa_user_id . '/contacts?%24async=false&%24' . $filter_string;
 		$all_contacts_request = wp_remote_get($url, $args);
 		// Ensure that responses are not empty
 		if (empty($all_contacts_request)) return;

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -482,6 +482,8 @@ class WA_Integration {
 		self::create_cron_for_user_refresh();
 		// Create event for checking license
 		self::setup_license_check_cron();
+		// schedule cron update for updating the membership levels and groups
+		Settings::setup_cron_job();
 
 		$login_title = 'Login with your WildApricot credentials';
 		$login_content = '[wawp_custom_login_form]';

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -281,9 +281,8 @@ class WA_Integration {
 		add_action('show_user_profile', array($this, 'show_membership_level_on_profile'));
 		add_action('edit_user_profile', array($this, 'show_membership_level_on_profile'));
 
-		// Fires on the post editor screen, adds custom meta boxes
-		add_action('load-post.php', array($this, 'post_access_meta_boxes_setup'));
-		add_action('load-post-new.php', array($this, 'post_access_meta_boxes_setup'));
+		// Fires on the add meta boxes hook, adds custom WAP meta boxes
+		add_action('add_meta_boxes', array($this, 'post_access_add_post_meta_boxes'));
 
 		// Fires when post is saved, processes custom post metadata
 		add_action('save_post', array($this, 'post_access_load_restrictions'), 10, 2);
@@ -747,10 +746,9 @@ class WA_Integration {
 	 */
 	public function post_access_load_restrictions($post_id, $post) {
 		if (Exception::fatal_error()) return;
-		// if this is the WA login page, return to avoid unneccessary invalid nonce log message
-		// if (str_contains(get_the_guid($post), 'wild-apricot-login')) return;
-		// if it's not the post edit page, don't do this
-		if (!is_post_edit_page()) return;
+
+		// if post isn't being saved *by the user*, return
+		if (!isset($_POST['action']) || $_POST['action'] != 'editpost') return;
 
 		// Verify the nonce before proceeding
 		if (!isset($_POST['wawp_post_access_control']) || !wp_verify_nonce($_POST['wawp_post_access_control'], basename(__FILE__))) {

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -355,13 +355,17 @@ class WA_Integration {
 			}
 		}
 
-		// re-validate license only if the plugin has been disabled
-		if (Addon::is_plugin_disabled() && !Exception::fatal_error()) {
+		$license_status = Addon::get_license_check_option(CORE_SLUG);
+
+		// re-validate license only if the plugin has been disabled and if the authorization credentials have not changed
+		if (Addon::is_plugin_disabled() && !Exception::fatal_error() && $license_status != Addon::LICENSE_STATUS_AUTH_CHANGED) {
 			Addon::update_licenses();
+			// obtain new status
+			$license_status = Addon::get_license_check_option(CORE_SLUG);
 		}
 
 		$has_valid_license = Addon::has_valid_license(CORE_SLUG);
-		$license_status = Addon::get_license_check_option(CORE_SLUG);
+		
 
 		// if there's been a fatal error or there are invalid creds then disable
 		if (Exception::fatal_error() || !$has_valid_license || !$has_valid_wa_credentials) {

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -358,7 +358,11 @@ class WA_Integration {
 		$license_status = Addon::get_license_check_option(CORE_SLUG);
 
 		// re-validate license only if the plugin has been disabled and if the authorization credentials have not changed
-		if (Addon::is_plugin_disabled() && !Exception::fatal_error() && $license_status != Addon::LICENSE_STATUS_AUTH_CHANGED) {
+		if (Addon::is_plugin_disabled() && 
+			!Exception::fatal_error() && 
+			$license_status != Addon::LICENSE_STATUS_AUTH_CHANGED && 
+			$has_valid_wa_credentials) 
+		{
 			Addon::update_licenses();
 			// obtain new status
 			$license_status = Addon::get_license_check_option(CORE_SLUG);


### PR DESCRIPTION
Closes #91 

When WA API authorization credentials change
- New license status added: authorization credentials changed
- Display admin notice prompting user to re-enter license key after new credentials are entered
- Clears all license keys including blocks

Other changes
- Unschedule CRON jobs when auth creds or license keys are invalid
- Retrieve custom fields data when API keys are valid instead of just in a daily CRON refresh
- Decrease width of license key input box