### PR TITLE
Cover sync options edge cases

### DIFF
--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -1234,25 +1234,14 @@ class WA_Auth_Settings {
 
             // encrypt valid credentials
             $data_encryption = new Data_Encryption();
-            $saved_auth_creds = WA_API::load_user_credentials();
-            $auth_creds_changed = false;
             foreach ($valid as $key => $value) {
-                if ($valid[$key] != $saved_auth_creds[$key]) {
-                    $auth_creds_changed = true;
-                }
                 $valid[$key] = $data_encryption->encrypt($value);
-
             }
         } catch (Exception $e) {
             Log::wap_log_error($e->getMessage(), true);
             return empty_string_array($input);
         } 
 
-        if ($auth_creds_changed) {
-            Addon::wa_auth_changed_update_status();
-            // if creds change delete old saved custom fields
-            delete_option(WA_Integration::LIST_OF_CHECKED_FIELDS);
-        }
 
         // Return array of valid inputs
         return $valid;
@@ -1385,9 +1374,17 @@ class WA_Auth_Settings {
         // Get WildApricot URL
         $wild_apricot_url_array = $wawp_api_instance->get_account_url_and_id();
         $wild_apricot_url = esc_url_raw($wild_apricot_url_array['Url']);
-        $wild_apricot_url_enc = $data_encryption->encrypt($wild_apricot_url);
 
-        $wawp_api_instance->retrieve_custom_fields();
+        // if wild apricot site changes, remove saved custom fields
+        $old_wa_url = get_option(WA_Integration::WA_URL_KEY);
+        $old_wa_url = $data_encryption->decrypt($old_wa_url);
+
+        if ($old_wa_url != $wild_apricot_url) {
+            Addon::wa_auth_changed_update_status();
+            delete_option(WA_Integration::LIST_OF_CHECKED_FIELDS);
+        }
+
+        $wild_apricot_url_enc = $data_encryption->encrypt($wild_apricot_url);
 
         // Save transients and options all at once; by this point all values should be valid.
         // Store access token and account ID as transients

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -607,9 +607,8 @@ class Admin_Settings {
 				<?php
             }
         } else { // no custom fields
-            $authorization_link = esc_url(site_url() . '/wp-admin/admin.php?page=wawp-login');
             ?>
-            <p>Your WildApricot site does not have any contact fields! Please ensure that you have correctly entered your WildApricot site's credentials under <a href="<?php echo esc_url($authorization_link); ?>">WildApricot Press -> Authorization</a></p>
+            <p>Your WildApricot site does not have any contact fields! Please ensure that you have correctly entered your WildApricot site's credentials under <a href="<?php echo esc_url(get_auth_menu_url()); ?>">WildApricot Press -> Authorization</a></p>
             <?php
         }
     }
@@ -635,6 +634,9 @@ class Admin_Settings {
                 $valid[$key] = sanitize_text_field($checkbox);
             }
         }
+
+        
+
         return $valid;
     }
 

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -587,6 +587,7 @@ class Admin_Settings {
      * @return void
      */
     public function custom_fields_input() {
+        WA_Integration::retrieve_custom_fields();
         // Load in custom fields
         $custom_fields = get_option(WA_Integration::LIST_OF_CUSTOM_FIELDS);
         $checked_fields = get_option(WA_Integration::LIST_OF_CHECKED_FIELDS);
@@ -1249,6 +1250,8 @@ class WA_Auth_Settings {
 
         if ($auth_creds_changed) {
             Addon::wa_auth_changed_update_status();
+            // if creds change delete old saved custom fields
+            delete_option(WA_Integration::LIST_OF_CHECKED_FIELDS);
         }
 
         // Return array of valid inputs

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -1377,7 +1377,7 @@ class WA_Auth_Settings {
         $wild_apricot_url_array = $wawp_api_instance->get_account_url_and_id();
         $wild_apricot_url = esc_url_raw($wild_apricot_url_array['Url']);
 
-        // if wild apricot site changes, remove saved custom fields
+        // if wild apricot site changes, remove saved custom fields and license
         $old_wa_url = get_option(WA_Integration::WA_URL_KEY);
         $old_wa_url = $data_encryption->decrypt($old_wa_url);
 

--- a/src/class-addon.php
+++ b/src/class-addon.php
@@ -228,6 +228,7 @@ class Addon {
                 self::invalid_license_key_notice($slug);
             } else if ($license_status == self::LICENSE_STATUS_AUTH_CHANGED) {
                 self::license_wa_auth_changed_notice($slug, $is_licensing_page);
+                return;
             }
         }
             

--- a/src/class-addon.php
+++ b/src/class-addon.php
@@ -487,6 +487,14 @@ class Addon {
             update_option(self::WAWP_DISABLED_OPTION, true);
         }
 
+        // remove membership levels, groups, and custom fields
+        delete_option(WA_Integration::WA_ALL_MEMBERSHIPS_KEY);
+        delete_option(WA_Integration::WA_ALL_GROUPS_KEY);
+        delete_option(WA_Integration::LIST_OF_CUSTOM_FIELDS);
+
+        // remove saved fields
+        delete_option(WA_Integration::LIST_OF_CHECKED_FIELDS);
+
         WA_Integration::delete_transients();
 
         Addon::unschedule_all_cron_jobs();

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -1612,12 +1612,12 @@ class WA_Integration {
 	private static function get_licensed_wa_urls($response) {
 		$licensed_wa_urls = array();
 
-		if (!array_key_exists('Licensed Wild Apricot URLs', $response)) {
+		if (!array_key_exists('Licensed WildApricot URLs', $response)) {
 			Log::wap_log_warning('Licensed WildApricot URLs missing from hook response.');
 			return null;
 		}
 
-		$licensed_wa_urls = $response['Licensed Wild Apricot URLs'];
+		$licensed_wa_urls = $response['Licensed WildApricot URLs'];
 		if (empty($licensed_wa_urls) || empty($licensed_wa_urls[0])) return null;
 
 		// Sanitize urls, if necessary
@@ -1638,12 +1638,12 @@ class WA_Integration {
 	private static function get_licensed_wa_ids($response) {
 		$licensed_wa_ids = array();
 
-		if (!array_key_exists('Licensed Wild Apricot Account IDs', $response)) {
+		if (!array_key_exists('Licensed WildApricot Account IDs', $response)) {
 			Log::wap_log_warning('License WildApricot IDs missing from hook response');
 			return null;
 		}
 
-		$licensed_wa_ids = $response['Licensed Wild Apricot Account IDs'];
+		$licensed_wa_ids = $response['Licensed WildApricot Account IDs'];
 		if (empty($licensed_wa_ids) || empty($licensed_wa_ids[0])) return null;
 
 		foreach ($licensed_wa_ids as $id_key => $id_value) {

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -365,10 +365,11 @@ class WA_Integration {
 			Addon::update_licenses();
 			// obtain new status
 			$license_status = Addon::get_license_check_option(CORE_SLUG);
+		} else if (!$has_valid_wa_credentials) {
+			$license_status = Addon::LICENSE_STATUS_NOT_ENTERED;
 		}
 
 		$has_valid_license = Addon::has_valid_license(CORE_SLUG);
-		
 
 		// if there's been a fatal error or there are invalid creds then disable
 		if (Exception::fatal_error() || !$has_valid_license || !$has_valid_wa_credentials) {
@@ -474,7 +475,8 @@ class WA_Integration {
     }
 
 	/**
-	 * Creates user-facing WildApricot login page
+	 * Creates user-facing WildApricot login page. Runs when both API key
+	 * and license key are found to be valid.
 	 *
 	 * @see https://stackoverflow.com/questions/32314278/how-to-create-a-new-wordpress-page-programmatically
 	 * @see https://stackoverflow.com/questions/13848052/create-a-new-page-with-wp-insert-post
@@ -1813,6 +1815,16 @@ class WA_Integration {
 		);
 
 		return $wa_meta;
+	}
+
+	public static function retrieve_custom_fields() {
+		// Create WA_API with valid credentials
+		$verified_data = WA_API::verify_valid_access_token();
+		$admin_access_token = $verified_data['access_token'];
+		$admin_account_id = $verified_data['wa_account_id'];
+		$wawp_api = new WA_API($admin_access_token, $admin_account_id);
+		// Refresh custom fields first
+		$wawp_api->retrieve_custom_fields();
 	}
 
 }

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -970,6 +970,8 @@ class WA_Integration {
 		// Get all post types, including built-in WordPress post types and custom post types
 		$post_types = get_post_types(array('public' => true));
 
+		if (Addon::is_plugin_disabled()) return;
+
 		// Add meta box for post access
 		add_meta_box(
 			'wawp_post_access_meta_box_id', // ID

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -365,8 +365,11 @@ class WA_Integration {
 			Addon::update_licenses();
 			// obtain new status
 			$license_status = Addon::get_license_check_option(CORE_SLUG);
-		} else if (!$has_valid_wa_credentials) {
-			$license_status = Addon::LICENSE_STATUS_NOT_ENTERED;
+		} 
+		
+		// if api creds aren't valid, remove licenses
+		if (!$has_valid_wa_credentials) {
+			delete_option(Addon::WAWP_LICENSE_KEYS_OPTION);
 		}
 
 		$has_valid_license = Addon::has_valid_license(CORE_SLUG);

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -366,16 +366,19 @@ class WA_Integration {
 			// obtain new status
 			$license_status = Addon::get_license_check_option(CORE_SLUG);
 		} 
-		
+
 		// if api creds aren't valid, remove licenses
-		if (!$has_valid_wa_credentials) {
+		if (!$has_valid_wa_credentials && !Addon::is_plugin_disabled()) {
 			delete_option(Addon::WAWP_LICENSE_KEYS_OPTION);
 		}
 
 		$has_valid_license = Addon::has_valid_license(CORE_SLUG);
 
 		// if there's been a fatal error or there are invalid creds then disable
-		if (Exception::fatal_error() || !$has_valid_license || !$has_valid_wa_credentials) {
+		if (Exception::fatal_error() ||
+			!$has_valid_license ||
+			!$has_valid_wa_credentials)
+		{
 			do_action('disable_plugin', CORE_SLUG, $license_status);
 		} else {
 			// if neither of the creds are invalid, do creds obtained action
@@ -999,20 +1002,6 @@ class WA_Integration {
 	}
 
 	/**
-	 * Sets up the post meta data for WildApricot access control if valid 
-	 * WildApricot credentials have already been entered.
-	 * 
-	 * @return void
-	 */
-	public function post_access_meta_boxes_setup() {
-		// Add meta boxes if and only if the WildApricot credentials have been entered and are valid
-		if (!Addon::is_plugin_disabled() && self::valid_wa_credentials() && Addon::has_valid_license(CORE_SLUG)) {
-			// Add meta boxes on the 'add_meta_boxes' hook
-			add_action('add_meta_boxes', array($this, 'post_access_add_post_meta_boxes'));
-		} 
-	}
-
-	/**
 	 * Display membership levels on user profile.
 	 *
 	 * @param WP_User $user is the user of the current profile
@@ -1486,125 +1475,125 @@ class WA_Integration {
 	 */
 	public function create_wa_login_logout($items, $args) {
 		// First, check if WildApricot credentials and the license is valid
-		if (self::valid_wa_credentials() && Addon::has_valid_license(CORE_SLUG)) {
-			// Check the restrictions of each item in header IF the header is not blank
-			if (!empty($items)) {
-				// Get navigation items
-				$args_menu = $args->menu;
-				$nav_items = wp_get_nav_menu_items($args_menu);
+		if (Addon::is_plugin_disabled()) return $items;
+		// Check the restrictions of each item in header IF the header is not blank
+		if (!empty($items)) {
+			// Get navigation items
+			$args_menu = $args->menu;
+			$nav_items = wp_get_nav_menu_items($args_menu);
 
-				// Get li tags from menu
-				$items = mb_convert_encoding($items, 'HTML-ENTITIES', 'UTF-8');;
-				$doc_items = new DOMDocument('1.0', 'utf-8');
-				libxml_use_internal_errors(true);
-				$doc_items->loadHTML($items, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD); // DOMDocument
-				libxml_clear_errors();
-				$li_tags = $doc_items->getElementsByTagName('li'); // DOMNodeList
+			// Get li tags from menu
+			$items = mb_convert_encoding($items, 'HTML-ENTITIES', 'UTF-8');;
+			$doc_items = new DOMDocument('1.0', 'utf-8');
+			libxml_use_internal_errors(true);
+			$doc_items->loadHTML($items, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD); // DOMDocument
+			libxml_clear_errors();
+			$li_tags = $doc_items->getElementsByTagName('li'); // DOMNodeList
 
-				$returned_html = '';
-				// Loop through each nav item, get the ID, and check if the page is restricted
-				if (!empty($nav_items)) {
-					$nav_item_number = 0; // used for keeping track of which navigation item we are looking at
-					foreach ($nav_items as $nav_item) {
-						$user_can_see = true;
-						// Get post id
-						$nav_item_id = $nav_item->object_id;
-						// Check if this post is restricted
-						$nav_item_is_restricted = get_post_meta($nav_item_id, self::IS_POST_RESTRICTED);
-						// If post is restricted, then check if the current has access to it
-						if (!empty($nav_item_is_restricted) && $nav_item_is_restricted[0]) {
-							if (is_user_logged_in()) { // user is logged in
-								// Check that user is synced with WildApricot
-								$current_users_id = get_current_user_id();
-								$users_wa_id = get_user_meta($current_users_id, self::WA_USER_ID_KEY);
-								// Check if user ID actually exists
-								if (!empty($users_wa_id) && $users_wa_id != '') { // User has been synced with WildApricot
-									// Check if user's status is within the allowed status(es)
-									$users_status = get_user_meta($current_users_id, self::WA_USER_STATUS_KEY);
-									$users_status = $users_status[0];
-									$allowed_statuses = get_option(self::RESTRICTION_STATUS);
-									// If some statuses have been checked off, then that means that some statuses are restricted
-									$valid_status = true;
-									if (!empty($allowed_statuses) && !empty($users_status)) {
-										// check if user status is contained in the allowed statuses
-										if (!in_array($users_status, $allowed_statuses)) {
-											// user cannot see this restricted post because their status is not allowed to see restricted posts
-											$valid_status = false;
-										}
+			$returned_html = '';
+			// Loop through each nav item, get the ID, and check if the page is restricted
+			if (!empty($nav_items)) {
+				$nav_item_number = 0; // used for keeping track of which navigation item we are looking at
+				foreach ($nav_items as $nav_item) {
+					$user_can_see = true;
+					// Get post id
+					$nav_item_id = $nav_item->object_id;
+					// Check if this post is restricted
+					$nav_item_is_restricted = get_post_meta($nav_item_id, self::IS_POST_RESTRICTED);
+					// If post is restricted, then check if the current has access to it
+					if (!empty($nav_item_is_restricted) && $nav_item_is_restricted[0]) {
+						if (is_user_logged_in()) { // user is logged in
+							// Check that user is synced with WildApricot
+							$current_users_id = get_current_user_id();
+							$users_wa_id = get_user_meta($current_users_id, self::WA_USER_ID_KEY);
+							// Check if user ID actually exists
+							if (!empty($users_wa_id) && $users_wa_id != '') { // User has been synced with WildApricot
+								// Check if user's status is within the allowed status(es)
+								$users_status = get_user_meta($current_users_id, self::WA_USER_STATUS_KEY);
+								$users_status = $users_status[0];
+								$allowed_statuses = get_option(self::RESTRICTION_STATUS);
+								// If some statuses have been checked off, then that means that some statuses are restricted
+								$valid_status = true;
+								if (!empty($allowed_statuses) && !empty($users_status)) {
+									// check if user status is contained in the allowed statuses
+									if (!in_array($users_status, $allowed_statuses)) {
+										// user cannot see this restricted post because their status is not allowed to see restricted posts
+										$valid_status = false;
 									}
-									// Now, check if the current user is allowed to see this page
-									// Get user's groups and level
-									$users_member_groups = get_user_meta($current_users_id, self::WA_MEMBER_GROUPS_KEY);
-									$users_member_groups = maybe_unserialize($users_member_groups[0]);
-									$user_member_level = get_user_meta($current_users_id, self::WA_MEMBERSHIP_LEVEL_ID_KEY);
-									$user_member_level = $user_member_level[0];
-									$wa_post_meta = self::get_wa_post_meta($nav_item_id);
-									// Get page's groups and level
-									$page_member_groups = $wa_post_meta[self::RESTRICTED_GROUPS];
-									$page_member_levels = $wa_post_meta[self::RESTRICTED_LEVELS];
-									// Check if user's groups/level overlap with the page's groups/level
-									$intersect_groups = array_intersect(array_keys($users_member_groups), $page_member_groups);
-									$intersect_level = in_array($user_member_level, $page_member_levels);
-									if ((empty($intersect_groups) && !$intersect_level) || !$valid_status) { // the user can't see this page!
-										// Remove this element from the menu
-										$user_can_see = false;
-									}
-								} else {
-									// User has not been synced with WildApricot; they therefore cannot see this in the menu
+								}
+								// Now, check if the current user is allowed to see this page
+								// Get user's groups and level
+								$users_member_groups = get_user_meta($current_users_id, self::WA_MEMBER_GROUPS_KEY);
+								$users_member_groups = maybe_unserialize($users_member_groups[0]);
+								$user_member_level = get_user_meta($current_users_id, self::WA_MEMBERSHIP_LEVEL_ID_KEY);
+								$user_member_level = $user_member_level[0];
+								$wa_post_meta = self::get_wa_post_meta($nav_item_id);
+								// Get page's groups and level
+								$page_member_groups = $wa_post_meta[self::RESTRICTED_GROUPS];
+								$page_member_levels = $wa_post_meta[self::RESTRICTED_LEVELS];
+								// Check if user's groups/level overlap with the page's groups/level
+								$intersect_groups = array_intersect(array_keys($users_member_groups), $page_member_groups);
+								$intersect_level = in_array($user_member_level, $page_member_levels);
+								if ((empty($intersect_groups) && !$intersect_level) || !$valid_status) { // the user can't see this page!
+									// Remove this element from the menu
 									$user_can_see = false;
 								}
 							} else {
-								// User is not logged in; page should definitely not be shown in menu
+								// User has not been synced with WildApricot; they therefore cannot see this in the menu
 								$user_can_see = false;
 							}
-						}
-
-						// Get associated HTML tag for this menu
-						$associated_html = $li_tags->item($nav_item_number);
-						// Add or remove hidden style
-						if ($user_can_see) {
-							$associated_html->removeAttribute('style');
 						} else {
-							$associated_html->setAttribute('style', 'display: none;');
+							// User is not logged in; page should definitely not be shown in menu
+							$user_can_see = false;
 						}
-
-						// Increment navigation item number
-						$nav_item_number++;
 					}
+
+					// Get associated HTML tag for this menu
+					$associated_html = $li_tags->item($nav_item_number);
+					// Add or remove hidden style
+					if ($user_can_see) {
+						$associated_html->removeAttribute('style');
+					} else {
+						$associated_html->setAttribute('style', 'display: none;');
+					}
+
+					// Increment navigation item number
+					$nav_item_number++;
 				}
-				// Get html to return
-				$returned_html .= $doc_items->saveHTML();
-				$items = $returned_html;
 			}
-
-			// https://wp-mix.com/wordpress-difference-between-home_url-site_url/
-			// Get current page id
-			// https://wordpress.stackexchange.com/questions/161711/how-to-get-current-page-id-outside-the-loop
-			$current_page_id = get_queried_object_id();
-			// Get login url
-			$login_url = $this->get_login_link();
-			$logout_url = wp_logout_url(esc_url(get_permalink($current_page_id)));
-			// Check if user is logged in or logged out, now an array
-			$selected_login_button_locations = get_login_menu_location();
-			// $selected_login_button_locations = get_option(WA_Integration::MENU_LOCATIONS_KEY);
-
-
-			if (empty($selected_login_button_locations)) return $items;
-
-			foreach ($selected_login_button_locations as $menu) {
-				if ($args->menu->term_id != $menu) continue;
-				if (is_user_logged_in()) { 
-					// Logout
-					$url = $logout_url;
-					$button_text = 'Log Out';
-				} elseif (!is_user_logged_in()) { 
-					// Login
-					$url = $login_url;
-					$button_text = 'Log In';
-				}
-				$items .= '<li id="wawp_login_logout_button" class="menu-item menu-item-type-post_type menu-item-object-page"><a href="'. esc_url($url) .'">' . esc_html($button_text) . '</a></li>';
-			}
+			// Get html to return
+			$returned_html .= $doc_items->saveHTML();
+			$items = $returned_html;
 		}
+
+		// https://wp-mix.com/wordpress-difference-between-home_url-site_url/
+		// Get current page id
+		// https://wordpress.stackexchange.com/questions/161711/how-to-get-current-page-id-outside-the-loop
+		$current_page_id = get_queried_object_id();
+		// Get login url
+		$login_url = $this->get_login_link();
+		$logout_url = wp_logout_url(esc_url(get_permalink($current_page_id)));
+		// Check if user is logged in or logged out, now an array
+		$selected_login_button_locations = get_login_menu_location();
+		// $selected_login_button_locations = get_option(WA_Integration::MENU_LOCATIONS_KEY);
+
+
+		if (empty($selected_login_button_locations)) return $items;
+
+		foreach ($selected_login_button_locations as $menu) {
+			if ($args->menu->term_id != $menu) continue;
+			if (is_user_logged_in()) { 
+				// Logout
+				$url = $logout_url;
+				$button_text = 'Log Out';
+			} elseif (!is_user_logged_in()) { 
+				// Login
+				$url = $login_url;
+				$button_text = 'Log In';
+			}
+			$items .= '<li id="wawp_login_logout_button" class="menu-item menu-item-type-post_type menu-item-object-page"><a href="'. esc_url($url) .'">' . esc_html($button_text) . '</a></li>';
+		}
+		
 		return $items;
 	}
 

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -1609,7 +1609,7 @@ class WA_Integration {
 		$licensed_wa_urls = array();
 
 		if (!array_key_exists('Licensed Wild Apricot URLs', $response)) {
-			Log::wap_log_warning('Licensed Wild Apricot URLs missing from hook response.');
+			Log::wap_log_warning('Licensed WildApricot URLs missing from hook response.');
 			return null;
 		}
 
@@ -1635,7 +1635,7 @@ class WA_Integration {
 		$licensed_wa_ids = array();
 
 		if (!array_key_exists('Licensed Wild Apricot Account IDs', $response)) {
-			Log::wap_log_warning('License Wild Apricot IDs missing from hook response');
+			Log::wap_log_warning('License WildApricot IDs missing from hook response');
 			return null;
 		}
 

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -1616,12 +1616,12 @@ class WA_Integration {
 	private static function get_licensed_wa_urls($response) {
 		$licensed_wa_urls = array();
 
-		if (!array_key_exists('Licensed WildApricot URLs', $response)) {
-			Log::wap_log_warning('Licensed WildApricot URLs missing from hook response.');
+		if (!array_key_exists('Licensed Wild Apricot URLs', $response)) {
+			Log::wap_log_warning('Licensed Wild Apricot URLs missing from hook response.');
 			return null;
 		}
 
-		$licensed_wa_urls = $response['Licensed WildApricot URLs'];
+		$licensed_wa_urls = $response['Licensed Wild Apricot URLs'];
 		if (empty($licensed_wa_urls) || empty($licensed_wa_urls[0])) return null;
 
 		// Sanitize urls, if necessary
@@ -1642,12 +1642,12 @@ class WA_Integration {
 	private static function get_licensed_wa_ids($response) {
 		$licensed_wa_ids = array();
 
-		if (!array_key_exists('Licensed WildApricot Account IDs', $response)) {
-			Log::wap_log_warning('License WildApricot IDs missing from hook response');
+		if (!array_key_exists('Licensed Wild Apricot Account IDs', $response)) {
+			Log::wap_log_warning('License Wild Apricot IDs missing from hook response');
 			return null;
 		}
 
-		$licensed_wa_ids = $response['Licensed WildApricot Account IDs'];
+		$licensed_wa_ids = $response['Licensed Wild Apricot Account IDs'];
 		if (empty($licensed_wa_ids) || empty($licensed_wa_ids[0])) return null;
 
 		foreach ($licensed_wa_ids as $id_key => $id_value) {


### PR DESCRIPTION
Closes #97 

- Reloads sync options every time the page is accessed to get most recent name changes or additions
  - Note: WildApricot does not update contact fields immediately after they are modified so it may take a minute for the changes to show up
- Clears stored contact fields and the checked contact fields when credentials are entered for a different *WildApricot website*, not for different API credentials since the credentials could be for the same site
- Update array keys used for finding the licensed WA URLs and IDs in the Make scenario response
- When license/credentials are invalid, remove custom fields
