### PR TITLE
Issues #125, 129, and 140

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tags: wildapricot, wild apricot, membership, event management, events, membershi
 Requires at least: 5.0
 Tested up to: 6.6.2
 Requires PHP: 7.4
-Stable Tag: 1.0.3
+Stable Tag: 1.1
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -198,6 +198,12 @@ By default, upon deletion of the WildApricot Press plugin, none of the data crea
 In Plugin Options tab you can turn on the "Print log messages to log file" to start logging errors and warnings to the filer wp-content/wapdebug.log. This can be used to troubleshoot plugin issues and provided to support.
 
 == Changelog ==
+
+= Version 1.1 - October xx, 2024 =
+
+- enable plugin debugging log by default
+- improved WA credentials validation flow
+- remove ability to sync admin-only fields 
 
 = Version 1.0.3 - October 2, 2024 =
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name:       NewPath WildApricot Press
  * Plugin URI:        https://newpathconsulting.com/wap
  * Description:       Integrates your WildApricot-powered organization with a WordPress website! Powered by WildApricot's API.
- * Version:           1.0.3
+ * Version:           1.1
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            NewPath Consulting

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -619,7 +619,7 @@ class Admin_Settings
     public function custom_fields_print_info()
     {
         print 'Please select the WildApricot Contact Fields that you would like to sync with your WordPress site.<br>';
-        print 'Admin-only contact fields are displayed below the list of contact fields but are not available to sync. If you wish to sync these fields with your site please change the field settings in Wild Apricot.';
+        print 'Admin-only contact fields are displayed below the list of contact fields but are not available to sync. If you wish to sync these fields with your site please change the field settings in WildApricot.';
     }
 
     /**
@@ -660,7 +660,7 @@ class Admin_Settings
     }
 
     /**
-     * Displays list of Wild Apricot member fields that have admin only access.
+     * Displays list of WildApricot member fields that have admin only access.
      *
      * @return void
      */
@@ -1304,7 +1304,7 @@ class WA_Auth_Settings
             echo '<p class="wap-error">Missing valid WildApricot credentials. Please enter them above.</p>';
         } elseif ($api_status == WA_Integration::API_STATUS_INCORRECT_SCOPE) {
             // incorrect scope selected
-            echo '<p class="wap-error">Incorrect application scope. Please create a <strong>full-access Server Application</strong> on Wild Apricot.</p>';
+            echo '<p class="wap-error">Incorrect application scope. Please create a <strong>full-access Server Application</strong> on WildApricot.</p>';
         } elseif ($api_status == WA_Integration::API_STATUS_VALID && $wild_apricot_url) {
             // successful login
             echo '<p class="wap-success">Valid WildApricot credentials have been saved.</p>';

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -1274,10 +1274,14 @@ class WA_Auth_Settings
 </div> <?php
             return;
         }
-        if (!WA_Integration::valid_wa_credentials()) {
+        $api_status = WA_Integration::get_api_input_status();
+        if ($api_status == WA_Integration::API_STATUS_INVALID) {
             // not valid
             echo '<p class="wap-error">Missing valid WildApricot credentials. Please enter them above.</p>';
-        } elseif ($wild_apricot_url) {
+        } elseif ($api_status == WA_Integration::API_STATUS_INCORRECT_SCOPE) {
+            // incorrect scope selected
+            echo '<p class="wap-error">Incorrect application scope. Please create a <strong>full-access Server Application</strong> on Wild Apricot.</p>';
+        } elseif ($api_status == WA_Integration::API_STATUS_VALID && $wild_apricot_url) {
             // successful login
             echo '<p class="wap-success">Valid WildApricot credentials have been saved.</p>';
             echo '<p class="wap-success">Your WordPress site has been connected to <b>' . esc_url($wild_apricot_url) . '</b>.</p>';
@@ -1316,10 +1320,21 @@ class WA_Auth_Settings
 
             $api_key = $valid[WA_Integration::WA_API_KEY_OPT];
             $valid_api = WA_API::is_application_valid($api_key);
-            // credentials invalid
+
+            // empty response from WA API --> credentials invalid
             if (!$valid_api) {
+                WA_Integration::set_api_status_invalid();
                 return empty_string_array($input);
             }
+
+            // application w/ full access has 15 accessible endpoints
+            $scope = count($valid_api['Permissions'][0]['AvailableScopes']);
+            if ($scope < 15) {
+                WA_Integration::set_api_status_incorrect_scope();
+                return empty_string_array($input);
+            }
+
+            WA_Integration::set_api_status_valid();
             self::obtain_and_save_wa_data_from_api($valid_api);
 
             // encrypt valid credentials

--- a/src/admin-settings.php
+++ b/src/admin-settings.php
@@ -618,7 +618,8 @@ class Admin_Settings
      */
     public function custom_fields_print_info()
     {
-        print 'Please select the WildApricot Contact Fields that you would like to sync with your WordPress site.';
+        print 'Please select the WildApricot Contact Fields that you would like to sync with your WordPress site.<br>';
+        print 'Admin-only contact fields are displayed below the list of contact fields but are not available to sync. If you wish to sync these fields with your site please change the field settings in Wild Apricot.';
     }
 
     /**
@@ -655,6 +656,22 @@ class Admin_Settings
     WildApricot site's credentials under <a href="<?php echo esc_url(get_auth_menu_url()); ?>">WildApricot
         Press -> Authorization</a></p>
 <?php
+        }
+    }
+
+    /**
+     * Displays list of Wild Apricot member fields that have admin only access.
+     *
+     * @return void
+     */
+    public function admin_fields_list()
+    {
+        $admin_fields = get_option(WA_Integration::LIST_OF_ADMIN_FIELDS);
+        if (!empty($admin_fields)) {
+            foreach ($admin_fields as $field_id => $field_name) {
+                ?> <input type="checkbox" disabled style="color:gray">
+<?php echo esc_html($field_name) ?> </input><br> <?php
+            }
         }
     }
 
@@ -962,6 +979,13 @@ class Admin_Settings
             array($this, 'custom_fields_input'), // callback
             'wawp-wal-admin&tab=fields', // page
             'wawp_fields_id' // section
+        );
+        add_settings_field(
+            'wawp_admin_field_id',
+            'Admin fields:',
+            array($this, 'admin_fields_list'),
+            'wawp-wal-admin&tab=fields',
+            'wawp_fields_id'
         );
     }
 

--- a/src/class-wa-api.php
+++ b/src/class-wa-api.php
@@ -265,20 +265,36 @@ class WA_API
             'Organization',
             'Membership status'
         );
+
         // Do not add 'Group participation' or 'User ID' because those are already used by default
         $custom_fields = array();
-        if (!empty($custom_field_response)) {
-            foreach ($custom_field_response as $field_response) {
-                $field_name = $field_response['FieldName'];
+        $admin_fields = array();
+        foreach ($custom_field_response as $field_response) {
+            $field_name = $field_response['FieldName'];
+            $field_id = '';
+            if (array_key_exists('SystemCode', $field_response)) {
                 $field_id = $field_response['SystemCode'];
-                // Ensure that we are not displaying default options
-                if (!in_array($field_name, $default_fields)) {
-                    $custom_fields[$field_id] = $field_name;
-                }
+            } else {
+                $field_id = str_replace(' ', '', $field_id);
+            }
+
+            // check access
+            // Ensure that we are not displaying default options
+
+            if (in_array($field_name, $default_fields)) {
+                continue;
+            }
+
+            if ($field_response['AdminOnly']) {
+                $admin_fields[$field_id] = $field_name;
+            } else {
+                $custom_fields[$field_id] = $field_name;
             }
         }
+        // TODO: update fields in user roles and checked fields
         // Save custom fields in the options table
         update_option(WA_Integration::LIST_OF_CUSTOM_FIELDS, $custom_fields);
+        update_option(WA_Integration::LIST_OF_ADMIN_FIELDS, $admin_fields);
     }
 
     /**

--- a/src/class-wa-api.php
+++ b/src/class-wa-api.php
@@ -218,7 +218,7 @@ class WA_API
         try {
             $details_response = self::response_to_data($response_api);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retrieving the Wild Apricot account URL and ID.');
+            throw new API_Exception('There was an error retrieving the WildApricot account URL and ID.');
         }
 
         // Extract values
@@ -253,7 +253,7 @@ class WA_API
         try {
             $custom_field_response = self::response_to_data($response_api);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retrieving the Wild Apricot custom fields.');
+            throw new API_Exception('There was an error retrieving the WildApricot custom fields.');
         }
 
 
@@ -468,7 +468,7 @@ class WA_API
         try {
             $data = self::response_to_data($response);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retrieving the Wild Apricot API access token.');
+            throw new API_Exception('There was an error retrieving the WildApricot API access token.');
         }
 
         return $data;
@@ -489,7 +489,7 @@ class WA_API
         try {
             $contact_info = self::response_to_data($contact_info);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retrieving Wild Apricot contact info.');
+            throw new API_Exception('There was an error retrieving WildApricot contact info.');
         }
 
         // Get if user is administrator or not
@@ -507,7 +507,7 @@ class WA_API
         try {
             $full_info = self::response_to_data($user_data_api);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retriving Wild Apricot user info.');
+            throw new API_Exception('There was an error retriving WildApricot user info.');
         }
 
         // Get all information for current user
@@ -533,7 +533,7 @@ class WA_API
         try {
             $membership_levels_response = self::response_to_data($membership_levels_response);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retrieving the Wild Apricot membership levels.');
+            throw new API_Exception('There was an error retrieving the WildApricot membership levels.');
         }
 
         // Extract membership levels into array
@@ -611,14 +611,14 @@ class WA_API
         try {
             $data = self::response_to_data($response);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error authorizing a Wild Apricot user\'s credentials.');
+            throw new API_Exception('There was an error authorizing a WildApricot user\'s credentials.');
         }
 
         return $data;
     }
 
     /**
-     * Retrieves list of contacts from Wild Apricot.
+     * Retrieves list of contacts from WildApricot.
      *
      * @param string $query additional query to append to the request url
      * @param boolean $block whether a single block is requested or not, used
@@ -667,7 +667,7 @@ class WA_API
     }
 
     /**
-     * Retrieves number of contacts from Wild Apricot.
+     * Retrieves number of contacts from WildApricot.
      *
      * @return int number of contacts
      */
@@ -689,7 +689,7 @@ class WA_API
             $data = self::response_to_data($response);
             $count = $data['Count'];
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retrieving the number of Wild Apricot contacts.');
+            throw new API_Exception('There was an error retrieving the number of WildApricot contacts.');
         }
 
         update_option(WA_Integration::WA_CONTACTS_COUNT_KEY, $count);
@@ -698,7 +698,7 @@ class WA_API
     }
 
     /**
-     * Requests a single block of contacts from Wild Apricot.
+     * Requests a single block of contacts from WildApricot.
      *
      * @param string $url base url to which to make the request
      * @param int $skip the number of contacts to skip from the beginning
@@ -723,7 +723,7 @@ class WA_API
         try {
             $data = self::response_to_data($response);
         } catch (API_Exception $e) {
-            throw new API_Exception('There was an error retrieving Wild Apricot contacts.');
+            throw new API_Exception('There was an error retrieving WildApricot contacts.');
         }
 
         return $data;

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -52,7 +52,7 @@ class WA_Integration
     public const WA_CLIENT_SECRET_OPT 					= 'wawp_wal_client_secret';
 
     /**
-     * Stores the validity status of the Wild Apricot API credentials.
+     * Stores the validity status of the WildApricot API credentials.
      *
      * @var string
      */
@@ -82,7 +82,7 @@ class WA_Integration
 
 
     /**
-     * Stores the total number of Wild Apricot contacts.
+     * Stores the total number of WildApricot contacts.
      */
     public const WA_CONTACTS_COUNT_KEY					= 'wawp_contacts_count';
 

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -52,6 +52,36 @@ class WA_Integration
     public const WA_CLIENT_SECRET_OPT 					= 'wawp_wal_client_secret';
 
     /**
+     * Stores the validity status of the Wild Apricot API credentials.
+     *
+     * @var string
+     */
+    public const API_STATUS_OPTION = 'wawp_api_status';
+
+    /**
+     * Valid WA API credentials.
+     *
+     * @var string
+     */
+    public const API_STATUS_VALID = 'valid';
+
+    /**
+     * Invalid WA API credentials.
+     *
+     * @var string
+     */
+    public const API_STATUS_INVALID = 'invalid';
+
+    /**
+     * WA API credentials have the incorrect scope - read only or
+     * WordPress credentials.
+     *
+     * @var string
+     */
+    public const API_STATUS_INCORRECT_SCOPE = 'incorrect_scope';
+
+
+    /**
      * Stores the total number of Wild Apricot contacts.
      */
     public const WA_CONTACTS_COUNT_KEY					= 'wawp_contacts_count';
@@ -346,6 +376,26 @@ class WA_Integration
 
         // check first that creds exist
         return !empty($api_key) && !empty($client_id) && !empty($client_secret);
+    }
+
+    public static function get_api_input_status()
+    {
+        return get_option(self::API_STATUS_OPTION);
+    }
+
+    public static function set_api_status_invalid()
+    {
+        update_option(self::API_STATUS_OPTION, self::API_STATUS_INVALID);
+    }
+
+    public static function set_api_status_incorrect_scope()
+    {
+        update_option(self::API_STATUS_OPTION, self::API_STATUS_INCORRECT_SCOPE);
+    }
+
+    public static function set_api_status_valid()
+    {
+        update_option(self::API_STATUS_OPTION, self::API_STATUS_VALID);
     }
 
     /**

--- a/src/class-wa-integration.php
+++ b/src/class-wa-integration.php
@@ -226,6 +226,13 @@ class WA_Integration
     public const LIST_OF_CUSTOM_FIELDS 				= 'wawp_list_of_custom_fields';
 
     /**
+     * Stores WA fields that are WA admin only for display in admin settings.
+     *
+     * @var string
+     */
+    public const LIST_OF_ADMIN_FIELDS               = 'wawp_list_of_admin_fields';
+
+    /**
      * Stores WA fields selected by user to sync with WordPress. Controlled in
      * admin settings.
      *

--- a/uninstall.php
+++ b/uninstall.php
@@ -55,13 +55,8 @@ function delete_all_db_data() {
 	// delete license data
 	WAWP\Addon::instance()::delete();
 
-	// data from wild apricot
-	delete_option(WAWP\WA_Integration::WA_ALL_MEMBERSHIPS_KEY);
-	delete_option(WAWP\WA_Integration::WA_ALL_GROUPS_KEY);
-	delete_option(WAWP\WA_Integration::LIST_OF_CUSTOM_FIELDS);
-	
-	// delete stored list of restricted post
-	delete_option(WAWP\WA_Integration::ARRAY_OF_RESTRICTED_POSTS);
+    delete_option(WAWP\WA_Integration::LIST_OF_ADMIN_FIELDS);
+
 
 	// delete exception flag
 	delete_option(WAWP\Exception::EXCEPTION_OPTION);


### PR DESCRIPTION
Issue #125 turn on debug log by default
- Added a flag in the options table to store whether the user has changed the debug log setting
- If it hasn't been changed, debug log is enabled on activation

Issue #129 Validate correct authorized application
- Server application has access to 15 endpoints
- Wild Apricot API will respond with a list of scopes. If there are less than 15, the user is prompted to change the application type to a server application

Issue #140 Remove admin-only fields
- Admin-only fields are separated into another list stored in the options table and displayed as `disabled` or grayed out checkboxes